### PR TITLE
유저 도메인 수정

### DIFF
--- a/src/main/java/com/healthmate/healthmate/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/healthmate/healthmate/domain/auth/controller/AuthController.java
@@ -18,7 +18,7 @@ public class AuthController {
 	@PostMapping("/signup")
 	public ResponseEntity<Void> signUp(@RequestBody SignUpRequest req) {
 		authService.signUp(req);
-		return ResponseEntity.ok().build();
+		return ResponseEntity.status(201).build();
 	}
 
 	@PostMapping("/signin")

--- a/src/main/java/com/healthmate/healthmate/domain/auth/dto/AuthDtos.java
+++ b/src/main/java/com/healthmate/healthmate/domain/auth/dto/AuthDtos.java
@@ -1,7 +1,7 @@
 package com.healthmate.healthmate.domain.auth.dto;
 
 public class AuthDtos {
-	public record SignUpRequest(String email, String password) {}
+	public record SignUpRequest(String email, String password, String dob, String nickname) {}
 	public record SignInRequest(String email, String password) {}
 	public record TokenResponse(String accessToken) {}
 }

--- a/src/main/java/com/healthmate/healthmate/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/healthmate/healthmate/domain/auth/service/AuthServiceImpl.java
@@ -22,9 +22,12 @@ public class AuthServiceImpl implements AuthService {
 	@Override
 	public void signUp(SignUpRequest req) {
 		if (userRepository.existsByEmail(req.email())) {
-			throw new IllegalArgumentException("Email already in use");
+			throw new IllegalArgumentException("EMAIL_DUPLICATE");
 		}
-		User user = new User(req.email(), passwordEncoder.encode(req.password()), UserRole.USER);
+		if (userRepository.existsByNickname(req.nickname())) {
+			throw new IllegalArgumentException("NICKNAME_DUPLICATE");
+		}
+		User user = new User(req.email(), passwordEncoder.encode(req.password()), req.dob(), req.nickname(), UserRole.USER);
 		userRepository.save(user);
 	}
 

--- a/src/main/java/com/healthmate/healthmate/domain/user/entity/User.java
+++ b/src/main/java/com/healthmate/healthmate/domain/user/entity/User.java
@@ -19,13 +19,21 @@ public class User {
 	@Column(nullable = false, length = 200)
 	private String password;
 
+	@Column(nullable = false)
+	private String dob;
+
+	@Column(nullable = false, unique = true, length = 10)
+	private String nickname;
+
 	@Column(nullable = false, length = 50)
 	@Enumerated(EnumType.STRING)
 	private UserRole role;
 
-	public User(String email, String password, UserRole role) {
+	public User(String email, String password, String dob, String nickname, UserRole role) {
 		this.email = email;
 		this.password = password;
+		this.dob = dob;
+		this.nickname = nickname;
 		this.role = role;
 	}
 }

--- a/src/main/java/com/healthmate/healthmate/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/healthmate/healthmate/domain/user/repository/UserRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
 	boolean existsByEmail(String email);
+	boolean existsByNickname(String nickname);
 }
 
 

--- a/src/main/java/com/healthmate/healthmate/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/healthmate/healthmate/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.healthmate.healthmate.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    public record ErrorResponse(String code, String message) {}
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
+        String code = ex.getMessage() != null ? ex.getMessage() : "BAD_REQUEST";
+        if ("EMAIL_DUPLICATE".equals(code)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse(code, "이미 사용중인 이메일입니다."));
+        }
+        if ("NICKNAME_DUPLICATE".equals(code)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse(code, "이미 사용중인 닉네임입니다."));
+        }
+        return ResponseEntity.badRequest().body(new ErrorResponse(code, "잘못된 요청입니다."));
+    }
+}
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
     url: ${DB_URL}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: false


### PR DESCRIPTION
- 생일, 닉네임 컬럼 추가
- 닉네임과 이메일 중복 시 회원가입 불가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 회원가입에 생년월일과 닉네임 필수 입력 추가(닉네임 최대 10자).
  - 이메일/닉네임 중복 시 409 응답과 표준화된 한글 오류 메시지 제공.
- Refactor
  - 회원가입 성공 응답 상태를 200에서 201 Created로 변경.
- Chores
  - 데이터베이스 스키마 초기화 전략을 create로 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->